### PR TITLE
出品ページマークアップ

### DIFF
--- a/app/assets/javascripts/items.coffee
+++ b/app/assets/javascripts/items.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/items.coffee
+++ b/app/assets/javascripts/items.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -1,0 +1,20 @@
+$(function() {
+  $('.sell-item-price').bind('keydown keyup keypress change',function(){
+    var putNumber = $(".sell-item-price").val();
+    if ( putNumber >= 300 ) {
+    var thisValue = $(this).val() * 0.1;
+    $('.sell-item-carc-right').html("¥" + Math.round(thisValue));
+    var calcValue = $(this).val() * 0.9;
+    $('.sell-item-ans-right').html("¥" + Math.round(calcValue));
+  }
+  });
+});
+
+$(function() {
+  $('.sell-image-dropbox')
+    .mouseover(function(e) {
+      $(this).css("cursor","pointer");
+    })
+    .mouseout(function(e) {
+    });
+});

--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -6,6 +6,9 @@ $(function() {
     $('.sell-item-carc-right').html("¥" + Math.round(thisValue));
     var calcValue = $(this).val() * 0.9;
     $('.sell-item-ans-right').html("¥" + Math.round(calcValue));
+  } else if(putNumber <= 300) {
+    $('.sell-item-carc-right').html("-");
+    $('.sell-item-ans-right').html("-");
   }
   });
 });

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -1,0 +1,336 @@
+// Place all the styles related to the items controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+$outline: #0099FF;
+
+.sell-item-container {
+  width: 700px;
+  margin: 0 auto;
+  &-container-inner {
+    min-height: 100vh;
+    margin: 0;
+    padding: 0;
+    overflow: auto;
+  }
+}
+
+.sell-container-inner {
+  background-color: white;
+  border-style: solid;
+  border-width: 0;
+  height: 97px;
+  line-height: 97px;
+}
+
+h2.sell-container-header {
+  text-align: center;
+  font-size: 22px;
+}
+
+form.sell-form {
+  border-top: 1px solid #eee;
+  height: 1919px;
+  background-color: white;
+}
+
+.sell-upload-box {
+  padding: 40px;
+  border-bottom: 1px solid #eee;
+}
+
+.sell-form-groups {
+    margin: 0 0 20px;
+}
+
+h3.sell-upload-text {
+  font-size: 16px;
+  line-height: 100%;
+}
+
+span.form-require {
+  background-color: #ea352d;
+  margin: 0 0 0 8px;
+  padding: 3px 5px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+  vertical-align: top;
+}
+
+p.upload-image {
+  margin: 8px 0 10px;
+  line-height: 1.5;
+  padding: 0;
+  font-size: 12px;
+}
+
+label.sell-image-dropbox {
+  display: block;
+  width: 620px;
+  height: 162px;
+  background: #f5f5f5;
+  border: 1px dashed #ccc;
+}
+
+
+pre.visible-pc {
+position: absolute;
+    top: 39%;
+    left: 16px;
+    right: 16px;
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    pointer-events: none;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.sell-items-content.clearfix {
+  padding: 40px 40px 10px;
+  line-height: 100%;
+  border-bottom: 1px solid #eee;
+  height:auto;
+  overflow: auto;
+}
+
+label.sell-item-name {
+  font-weight: 600;
+  font-size: 14px;
+    &-left {
+    font-weight: 600;
+    font-size: 14px;
+    float: left;
+  }
+}
+
+.input-form-groups {
+  margin: 0 0 40px;
+}
+
+input.sell-item-name {
+  height: 30px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  line-height: 1.5;
+  font-size: 16px;
+  width: 95%;
+  margin: 8px auto;
+  &:focus {
+    outline: 0;
+    border: 0.5px solid $outline;
+  }
+}
+
+
+textarea.sell-item-info {
+  display: block;
+  width: 97%;
+  max-width: 100%;
+  min-height: 104px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 15.9px;
+  line-height: 1.5;
+  margin: 8px 0 0;
+  overflow: auto;
+  &:focus {
+    outline: 0;
+    border: 0.5px solid $outline;
+  }
+}
+
+
+h3.sell-detail-text {
+  float: left;
+  color: #888;
+  font-size: 14px;
+  line-height: 100%;
+}
+
+.sell-form-box {
+  float: right;
+  width: 400px;
+  margin: 0;
+}
+
+.select-wrap-category {
+  margin: 8px 0 0;
+  position: relative;
+}
+
+select.select-category {
+  -webkit-appearance: none;
+  z-index: 2;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  width:100%;
+    &:focus {
+    outline: 0;
+    border: 0.5px solid $outline;
+    }
+}
+
+i.fas.fa-angle-down:before {
+  position: absolute;
+    right: 16px;
+    top: 40%;
+    z-index: 2;
+    color: #888;
+    font-size: 20px;
+    -webkit-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    font-weight: solid;
+}
+
+span.form-any {
+  background-color: #ccc;
+  margin: 0 0 0 8px;
+  padding: 3px 5px;
+  border-radius: 2px;
+  line-height: 100%;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+  vertical-align: top;
+}
+
+h3.sell-price-text {
+  float: left;
+  color: #888;
+  font-size: 12px;
+  line-height: 100%;
+}
+i.fas.fa-question-circle {
+  color: $outline;
+}
+
+.sell-item-price-left {
+  float:left;
+    width: 25%;
+    height: 30px;
+
+
+}
+
+.sell-item-price-right {
+  float:right;
+}
+
+input.sell-item-price {
+  height: 30px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  line-height: 1.5;
+  font-size: 14px;
+  width: 140px;
+  margin: 8px auto;
+  text-align: right;
+    &:focus {
+    outline: 0;
+    border: 0.5px solid $outline;
+    }
+}
+.sell-form-groups-list {
+    height: 80px;
+    border-bottom: 1px solid #eee;
+    line-height: 80px;
+    &-calc {
+      position: relative;
+      line-height: 80px;
+      }
+}
+
+.sell-item-carc-left {
+    font-size: 13px;
+    float: left;
+}
+
+.sell-item-carc-right {
+    font-size: 11px;
+    line-height: 80px;
+    position: absolute;
+    right: 230px;
+    text-align: right;
+    min-width: 10%;
+    color: black;
+}
+
+.sell-item-ans-left {
+  float: left;
+  font-weight: bold;
+}
+.sell-item-ans-right {
+  float: right;
+  text-align: right;
+  font-weight: bold;
+  font-size: 27px;
+}
+
+.sell-items-content-calc {
+  padding: 40px 40px 80px;
+  line-height: 100%;
+  border-bottom: 1px solid #eee;
+  height:auto;
+  overflow: auto;
+}
+
+.sell-form-groups-list-ans {
+    height: 80px;
+    line-height: 80px;
+  }
+
+.sell-items-content-btn {
+  padding: 40px 40px 10px;
+  line-height: 100%;
+  min-height: 270px;
+  height:auto;
+  overflow: auto;
+  background-color: white;
+  position: relative;
+}
+
+.sell-items-coution-box {
+  line-height: 1.5;
+  font-size: 13.8px;
+}
+
+a.sell-coution-message {
+  text-decoration: none;
+  color: $outline;
+}
+
+button.send-sell-btn {
+  margin: 40px 0 0;
+  width: 100%;
+  height: 50px;
+  background-color: #ea352d;
+  border: 1px solid #ea352d;
+  font-size: 14px;
+  color: white;
+}
+button.back-sell-btn {
+  width: 300px;
+  height: 50px;
+  background-color: #aaa;
+  border: 1px solid #aaa;
+  font-size: 14px;
+  color: white;
+  position: absolute;
+  top: 230px;
+  left: 200px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,3 @@
+class ItemsController < ApplicationController
+  def sell; end
+end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,0 +1,2 @@
+module ItemsHelper
+end

--- a/app/views/items/sell.html.haml
+++ b/app/views/items/sell.html.haml
@@ -1,7 +1,7 @@
 .mercari-header
   %h1
-    %a{:href => "#"}
-      %img{src: "/assets/logo.svg", :style => "background: rgb(245, 245, 245);"}/
+    %a{href: "#"}
+      %img{src: "logo.svg", style: "background: rgb(245, 245, 245);"}/
 
 .sell-main-content.clearfix
   .sell-item-container
@@ -166,11 +166,6 @@
         %button.back-sell-btn
           もどる
 
-
-
-
-
-
 .mercari-footer
   %nav
     %ul
@@ -178,7 +173,7 @@
       %li メルカリ利用規約
       %li 特定商取引に関する表記
   .mercari-footer_contents
-    %a.single-footer-logo{:href => "#"}
-      %img{:src => "/assets/mercari.svg", :style => "background: rgb(245, 245, 245);"}/
+    %a.single-footer-logo{href: "#"}
+      %img{src: "mercari.svg", style: "background: rgb(245, 245, 245);"}/
     %p
       %small © 2019 Mercari

--- a/app/views/items/sell.html.haml
+++ b/app/views/items/sell.html.haml
@@ -1,7 +1,7 @@
 .mercari-header
   %h1
-    %a{href: "#"}
-      %img{src: "logo.svg", style: "background: rgb(245, 245, 245);"}/
+    = link_to root_path do
+      =image_tag asset_path "logo.svg", style: "background: rgb(245, 245, 245);"
 
 .sell-main-content.clearfix
   .sell-item-container
@@ -173,7 +173,7 @@
       %li メルカリ利用規約
       %li 特定商取引に関する表記
   .mercari-footer_contents
-    %a.single-footer-logo{href: "#"}
-      %img{src: "mercari.svg", style: "background: rgb(245, 245, 245);"}/
+    =link_to root_path, class: "single-footer-logo" do
+      =image_tag asset_path "mercari.svg", style: "background: rgb(245, 245, 245);"
     %p
       %small © 2019 Mercari

--- a/app/views/items/sell.html.haml
+++ b/app/views/items/sell.html.haml
@@ -1,0 +1,184 @@
+.mercari-header
+  %h1
+    %a{:href => "#"}
+      %img{src: "/assets/logo.svg", :style => "background: rgb(245, 245, 245);"}/
+
+.sell-main-content.clearfix
+  .sell-item-container
+    .sell-container-inner
+      %h2.sell-container-header 商品の情報を入力
+    %form.sell-form
+      .sell-upload-box
+        %h3.sell-upload-text
+          出品画像
+          %span.form-require 必須
+        %p.upload-image 最大10枚までアップロード出来ます
+        %label.sell-image-dropbox
+          %input.sell-upload-drop-file{type: "file", name: "sellimage", style: "display: none;"}
+          %pre.visible-pc
+            ドラッグアンドドロップ
+            またはクリックしてファイルをアップロード
+      .sell-items-content.clearfix
+        .form-item-name
+          %label.sell-item-name
+            商品名
+            %span.form-require 必須
+        .input-form-groups
+          %input.sell-item-name{type: "text", placeholder: "商品名（必須40文字まで）"}
+        .input-form-groups
+          .form-item-name
+            %label.sell-item-name
+              商品の説明
+              %span.form-require 必須
+          %textarea.sell-item-info{type: "input",rows: "5", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"}
+      .sell-items-content.clearfix
+        %h3.sell-detail-text
+          商品の詳細
+        .sell-form-box
+          .sell-form-groups
+            %label.sell-item-name
+              カテゴリー
+              %span.form-require 必須
+              .select-wrap-category
+                %select.select-category
+                  %option ---
+                  %option{value: "1"} レディース
+                  %option{value: "2"} メンズ
+                  %option{value: "3"} ベビーキッズ
+                  %option{value: "4"} インテリア・住まい・小物
+                  %option{value: "5"} 本・音楽・ゲーム
+                  %option{value: "1328"} おもちゃ・ホビー・グッズ
+                  %option{value: "6"} コスメ・香水・美容
+                  %option{value: "7"} 家電・スマホ・カメラ
+                  %option{value: "8"} スポーツ・レジャー
+                  %option{value: "9"} ハンドメイド
+                  %option{value: "1027"} チケット
+                  %option{value: "1318"} 自動車・オートバイ
+                  %option{value: "10"} その他
+                %i.fas.fa-angle-down
+
+          .sell-form-groups
+            %label.sell-item-name
+              商品の状態
+              %span.form-require 必須
+              .select-wrap-category
+                %select.select-category
+                  %option ---
+                  %option{value: "1"} 新品、未使用品
+                  %option{value: "2"} 未使用に近い
+                  %option{value: "3"} 目立った傷や汚れなし
+                  %option{value: "4"} やや傷や汚れあり
+                  %option{value: "5"} 全体的に状態が悪い
+                %i.fas.fa-angle-down
+
+
+      .sell-items-content.clearfix
+        %h3.sell-detail-text
+          配送について
+          = link_to items_sell_path do
+            %i.fas.fa-question-circle
+        .sell-form-box
+          .sell-form-groups
+            %label.sell-item-name
+              発送料の負担
+              %span.form-require 必須
+              .select-wrap-category
+                %select.select-category
+                  %option ---
+                  %option{value: "2"} 送料込み（出品者負担）
+                  %option{value: "1"} 着払い（購入者負担）
+                %i.fas.fa-angle-down
+
+          .sell-form-groups
+            %label.sell-item-name
+              発送元の地域
+              %span.form-require 必須
+              .select-wrap-category
+                %select.select-category
+                  %option ---
+                  %option{value: "1"} 関西
+                  %option{value: "2"} 北海道
+                  %option{value: "3"} 東北
+                  %option{value: "4"} 関東
+                  %option{value: "5"} 中部
+                  %option{value: "6"} 四国
+                  %option{value: "7"} 九州
+                  %option{value: "8"} 沖縄
+                %i.fas.fa-angle-down
+
+          .sell-form-groups
+            %label.sell-item-name
+              発送までの日数
+              %span.form-require 必須
+              .select-wrap-category
+                %select.select-category
+                  %option ---
+                  %option{value: "1"} 1~2日で発送
+                  %option{value: "2"} 2~3日で発送
+                  %option{value: "3"} 4~7日で発送
+                %i.fas.fa-angle-down
+
+      .sell-items-content-calc
+        %h3.sell-price-text
+          販売価格(300〜9,999,999)
+          = link_to items_sell_path do
+            %i.fas.fa-question-circle
+        .sell-form-box
+          .sell-form-groups-list
+            .sell-item-price-left
+              %label.sell-item-name-left
+                価格
+                %span.form-require 必須
+            .sell-item-price-right
+              .input-form-groups
+                ¥
+                %input.sell-item-price{type: "text", placeholder: "例）300"}
+          .sell-form-groups-list
+            .sell-item-carc-left
+              販売手数料(10%)
+            .sell-item-carc-right
+              ー
+          .sell-form-groups-list-ans
+            .sell-item-ans-left
+              販売利益
+            .sell-item-ans-right -
+
+      .sell-items-content-btn
+        .sell-items-coution-box
+          =link_to items_sell_path, class: "sell-coution-message"  do
+            禁止されている出品
+          、
+          =link_to items_sell_path, class: "sell-coution-message" do
+            行為
+          を必ずご確認ください。
+          .coution-middle
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          =link_to items_sell_path, class: "sell-coution-message" do
+            偽ブランドの販売
+          は犯罪であり処罰される可能性があります。
+          .coution-bottom
+          また、出品を持ちまして
+          =link_to items_sell_path, class: "sell-coution-message" do
+            加盟店規約
+          に同意したことになります。
+        %button.send-sell-btn
+          出品する
+        %button.back-sell-btn
+          もどる
+
+
+
+
+
+
+.mercari-footer
+  %nav
+    %ul
+      %li プライバシーポリシー
+      %li メルカリ利用規約
+      %li 特定商取引に関する表記
+  .mercari-footer_contents
+    %a.single-footer-logo{:href => "#"}
+      %img{:src => "/assets/mercari.svg", :style => "background: rgb(245, 245, 245);"}/
+    %p
+      %small © 2019 Mercari

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   get 'users/adress' => 'users#adress'
   get 'users/credit' => 'users#credit'
   get 'users/finish' => 'users#finish'
+
+  get 'items/sell'   => 'items#sell'
 end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,7 +1,4 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
 end


### PR DESCRIPTION
# What
出品ページマークアップの実装
・画像投稿のファイルはページの%label.sell-image-dropbox範囲内のどこを押しても、ファイル選択できる。
・selectとoptionは仮置きで設置
・販売利益の計算はjQueryで300円以上であれば表示するように記載。

# Why
後のサーバーサイドの実装を行うにあたり、必要となるリンクは仮置き
機能実装に伴い、わかり易いビューを意識した作成。

https://gyazo.com/c300fb53d50a80c12117234b35167240