### PR TITLE
商品詳細ページ（サーバーサイド）の実装

### DIFF
--- a/app/assets/stylesheets/_item-content-box.scss
+++ b/app/assets/stylesheets/_item-content-box.scss
@@ -42,6 +42,8 @@
           display:inline-block;
           width:33.3%;
           float:left;
+          height: 63px;
+          overflow: hidden;
           img{
             max-width:95%;
             margin:0 0 5px 0;
@@ -392,4 +394,9 @@
 
 .sub-image li img:hover{
   opacity: 0.5;
+}
+
+li.item-sub-images {
+  width: 99px;
+  height:63px;
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,8 +10,8 @@ class ItemsController < ApplicationController
 
   def show
     @item  = Item.includes(:category, :item_images, :brand, :size, :seller).find(params[:id])
-    @nike_brand     = Item.includes(:brand).where(brand_id: 1).limit(6).newest
-    @adidas_brand   = Item.includes(:brand).where(brand_id: 2).limit(6).newest
+    @nike_brand     = Item.includes(:brand).where(brand_id: NIKE_BRAND_ID).limit(6).newest
+    @adidas_brand   = Item.includes(:brand).where(brand_id: ADIDAS_BRAND_ID).limit(6).newest
   end
 
   def sell

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,9 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item  = Item.includes(:category, :item_images, :brand, :size, :seller).find(params[:id])
+    @nike_brand     = Item.includes(:brand).where(brand_id: 1).limit(6).newest
+    @adidas_brand   = Item.includes(:brand).where(brand_id: 2).limit(6).newest
   end
 
   def sell

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,5 +1,5 @@
 .items-box
-  = link_to items_path(item.id) do
+  = link_to item_path(item.id) do
     -item.item_images.each.with_index do |image, i|
       - if i ==0
         =image_tag image.image.url

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,4 +1,4 @@
 = render "layouts/header"
-= render "layouts/mainpage" ,collection: @itemss
+= render "layouts/mainpage" ,collection: @items
 = render "layouts/footer"
 = render "layouts/sellbutton"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,29 +9,28 @@
       %li{itemscope: "", itemtype: ""}
         %span{itemprop: "title"}sample
   %section.itembox-container
-    %h1.item-name [新品]テスト用！ダウンコート！[新品]
+    %h1.item-name
+      = @item.name
     .item-main-content
       .item-photo
         .main-image
-          =image_tag asset_path "dum02.gif"
+          -@item.item_images.each.with_index do |image, i|
+            - if i ==0
+              =image_tag image.image.url
         .image-detail
           %ul.sub-image
-            %li
-              =image_tag asset_path "dum02.gif"
-            %li
-              =image_tag asset_path "dum04.gif"
-            %li
-              =image_tag asset_path "banner/dum01.gif"
-            %li
-              =image_tag asset_path "banner/dum03.gif"
-            %li
-              =image_tag asset_path "banner/dum05.gif"
+            -@item.item_images.each.with_index do |image, i|
+              - if i <=10
+                %li
+                  =image_tag image.image.url
+
       %table.item-detail-table
         %tbody
           %tr
             %th 出品者
             %td
-              = link_to 'マリオ・ザガロ',""
+              = link_to users_show_path do
+                = @item.seller.nickname
               .rating-box
                 .user-rating
                   = fa_icon ("grin")
@@ -45,59 +44,68 @@
           %tr
             %th カテゴリー
             %td
-              =link_to ""  do
-                .name メンズ
-              =link_to ""  do
+              =link_to root_path do
+                .name
+                  = @item.category.category_name
+              =link_to root_path do
                 .sub-name
                   =fa_icon("angle-right")
-                  ジャケット
-              =link_to ""  do
+                  パンクズ時に実装
+              =link_to root_path do
                 .middle-name
                   =fa_icon("angle-right")
-                  ダウンコート
+                  パンクズ時に実装
           %tr
             %th ブランド
             %td
-              =link_to "" do
-                .item-brand ブッチ
+              =link_to root_path do
+                .item-brand
+                  = @item.brand.name
           %tr
             %th 商品のサイズ
-            %td LL
+            %td
+              = @item.size.name
           %tr
             %th 商品の状態
-            %td 新品・未使用
+            %td
+              = @item.condition
           %tr
             %th 配送料の負担
-            %td 送料込み(出品者負担)
+            %td
+              = @item.shippingfee
           %tr
             %th 配送の方法
             %td ゆうゆうメルカリ便
           %tr
             %th 配送元地域
             %td
-              = link_to 'ブラジル',""
+              = link_to root_path do
+                = @item.shipfrom
           %tr
             %th 発送日の目安
-            %td 2~3日で発送
+            %td
+              = @item.shipping_date
     .item-price-box
-      %span.item-price-money ¥ 140,000
+      %span.item-price-money
+        ¥
+        = number_with_delimiter(@item.price)
       %span.item-tax (税込)
       %span.item-free 送料込み
     =link_to '購入画面に進む',"",class: "btn item-buy"
     .item-description
       %p.itemdecription-in
-      【新品】無印良品 オーストラリアダウン水を弾くフードコート L・黒オーストラリアダウン水を弾くフードコート（ダウンコート・ベンチコート)・黒・Lです。ファーは取り外し可能（ファスナータイプ）です。スタッフ用ベンチコートとして購入しましたが、他のもう少し安いアウトドアブランドのを購入しましたので、こちらは出品します。一点のみです。✴︎写真は無印良品公式サイトより引用フィルパワー750のオーストラリアダウンをふんだんに使用し、撥水加工が施された生地は水をよく弾き、寒さだけでなく、雨風にも強い仕立てになっております。新品です。取り置き、専用などには対応しておりません。あらかじめご了承ください。万一、値引きする場合、こちらのタイミングで決めます。また完全無欠な商品をお求めの方は、そもそもこのような場所で購入してはいけません。通常の店舗、ネットにて購入してください。メーカー：無印良品状態：新品サイズ：L胸囲：96 - 104cm身長：175 - 185ｃｍ素材：・表地：ポリエステル100%・裏地：ポリエステル100%・中わた：ダウン90%・フェザー10%・リブ部分：アクリル78%・ポリエステル12%・ウール9%・ポリウレタン1%・ファー部分：アクリル85%・ポリエステル15%カラー：黒価格：25,900円禁煙・ペットなしです。✴︎土日祝日の発送は基本的に対応しておりません。✴︎「専用」には応じません。✴︎写真はカメラやモニターにより光の加減から実際の色とは多少の違いが生じる場合があります。あらかじめご了承ください。✴︎出来るだけコンパクトに折りたたみ、簡易包装で発送致しますので、あらかじめご了承ください。
+        = @item.introduction
     .item-button-container
       .item-button-left
-        =link_to "", class: "btn item-button-like" do
+        =link_to transactions_buy_path(@item.id), class: "btn item-button-like" do
           =fa_icon("heart")
           %span いいね!
           %span.fade-in 0
-        = link_to "", class: "btn item-button-report" do
+        = link_to root_path, class: "btn item-button-report" do
           =fa_icon("flag")
           %span 不適切な商品の報告
       .item-button-right
-        =link_to "" do
+        =link_to root_path do
           = fa_icon("user-lock")
           %span あんしん・あんぜんへの取り組み
 
@@ -111,130 +119,42 @@
             %span コメントする
   %ul.nav-item-link
     %li.item-prev
-      = link_to "" do
+      = link_to root_path do
         =fa_icon("angle-left")
         ジーパン
     %li.item-next
-      = link_to "" do
+      = link_to root_path do
         ジャンパー
         =fa_icon("angle-right")
   .item-social-box
     %ul.social-media-box
       %li
-        =link_to "",class: "btn share-btn" do
+        =link_to root_path,class: "btn share-btn" do
           %i.fab.fa-facebook-square.fa-3x
       %li
-        =link_to "",class: "btn share-btn" do
+        =link_to root_path,class: "btn share-btn" do
           %i.fab.fa-twitter-square.fa-3x
       %li
-        =link_to "",class: "btn share-btn" do
+        =link_to root_path,class: "btn share-btn" do
           %i.fab.fa-pinterest-square.fa-3x
 
   .item-inuser-profile
     %section.item-box-inuser
       .main-section
-        %h2.section-name マリオ・ザガロのその他商品
+        %h2.section-name
+          NIKEのその他商品
         .section-item
-          .items-box
-            = link_to "" do
-              =image_tag asset_path"banner/dum01.gif"
-              .item-box-body
-                .item-box-name テストの商品です
-                .item-box-price
-                  .price-section¥7,777
-                  .item-liks
-                    =fa_icon("heart")
-                    %span 10
-                  %p.item-tax (税込)
-          .items-box
-            = link_to "" do
-              =image_tag asset_path"banner/dum01.gif"
-              .item-box-body
-                .item-box-name テストの商品です
-                .item-box-price
-                  .price-section¥7,777
-                  .item-liks
-                    =fa_icon("heart")
-                    %span 10
-                  %p.item-tax (税込)
-          .items-box
-            = link_to "" do
-              =image_tag asset_path"banner/dum01.gif"
-              .item-box-body
-                .item-box-name テストの商品です
-                .item-box-price
-                  .price-section¥7,777
-                  .item-liks
-                    =fa_icon("heart")
-                    %span 10
-                  %p.item-tax (税込)
+          - @nike_brand.each do |item|
+            = render partial: 'item', locals: { item: item }
+      .section-all
+        = link_to'すべての商品を見る',""
+
     %section.item-box-overflow
-      %h2.section-brand ブッチ 新着アイテム
+      %h2.section-brand アディダス 新着アイテム
       .brand-item
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
-        .items-box
-          = link_to "" do
-            =image_tag asset_path"banner/dum01.gif"
-            .item-box-body
-              .item-box-name テストの商品です
-              .item-box-price
-                .price-section¥7,777
-                .item-liks
-                  =fa_icon("heart")
-                  %span 10
-                %p.item-tax (税込)
+        - @nike_brand.each do |item|
+          = render partial: 'item', locals: { item: item }
+      .section-all
+        = link_to'すべての商品を見る',""
+
 = render "layouts/footer"

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,6 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+  NIKE_BRAND_ID = 1
+  ADIDAS_BRAND_ID = 2

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -13,4 +13,13 @@ describe ItemsController do
       expect(response).to render_template :index
     end
   end
+
+  describe 'Get #show' do
+    it '@itemに要求されたitemを割り当てること' do
+      expect(assigns(:item)).to eq @item
+    end
+    it 'renders the :show template' do
+      expect(response).to render_template :show["id"]
+    end
+  end
 end


### PR DESCRIPTION
# What
indexで表示された商品をクリックしたら詳細ページに飛ぶように設定。
items controllerで関連づいたモデルからデータを取り出し、itemのidと連動させている。
写真が縦長だと表示が崩れるので、cssを修正。
パンクズの実装時にカテゴリ欄は修正予定

# Why
items controllerで取得したデータを@itemで表示。
写真についてはeach_with_indexで表示回数を指定した。
number_with_delimiter(@item.price)で３桁毎にカンマが入るようにした。

https://gyazo.com/2fd6be4997859ad69b358fe137ae1fec