### PR TITLE
商品編集ページの実装（商品編集ページへの移行、商品データ編集）（未完）

### DIFF
--- a/app/assets/stylesheets/_color.scss
+++ b/app/assets/stylesheets/_color.scss
@@ -3,4 +3,4 @@ $white: #fff;
 $gray: #eee;
 $redbtn: #ea352d;
 $outline: #0099FF;
-$graybtn: #ccc;
+$graybtn: #aaa;

--- a/app/assets/stylesheets/_item-edit.scss
+++ b/app/assets/stylesheets/_item-edit.scss
@@ -1,0 +1,122 @@
+p.choice {
+  text-align: center;
+}
+
+button.stop-sell-btn {
+  margin: 0 auto;
+  margin-bottom:20px;
+  width: 100%;
+  height: 50px;
+  background-color: $graybtn;
+  border: 1px solid $graybtn;
+  font-size: 14px;
+  color: white;
+}
+
+button.delete-sell-btn {
+  margin: 0 auto;
+  width: 100%;
+  height: 50px;
+  background-color: $graybtn;
+  border: 1px solid $graybtn;
+  font-size: 14px;
+  color: white;
+}
+button:hover {
+  opacity: 0.7;
+  cursor : pointer;
+}
+
+section.itembox-container-signin {
+    display: block;
+    background-color: white;
+    margin: 40px auto 0;
+    width: 620px;
+}
+
+button.send-edit-btn {
+    margin: 40px 0 0;
+    width: 100%;
+    height: 50px;
+    background-color: #ea352d;
+    border: 1px solid #ea352d;
+    font-size: 14px;
+    color: white;
+}
+
+.select-edit-category {
+  margin: 8px 0 0;
+  position: relative;
+  select{
+    -webkit-appearance: none;
+    z-index: 2;
+    height: 48px;
+    padding: 0 16px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background: 0;
+    font-size: 16px;
+    line-height: 1.5;
+    cursor: pointer;
+    width:100%;
+    &:focus {
+      outline: 0;
+      border: 0.5px solid $outline;
+    }
+  }
+}
+#child{
+  select {
+    display:none;
+    position:absolute;
+    top:0px;
+  }
+  i{
+    display:none;
+  }
+}
+#child select.on {
+  display:block;
+  margin: 8px 0 0;
+  position: relative;
+  -webkit-appearance: none;
+  z-index: 2;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  width:100%;
+  &:focus {
+    outline: 0;
+    border: 0.5px solid $outline;
+  }
+}
+#chi{
+  display: none;
+  width: 400px;
+}
+i.fas.fa-angle-down:before {
+  position: absolute;
+    right: 16px;
+    top: 40%;
+    z-index: 2;
+    color: #888;
+    font-size: 20px;
+    -webkit-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    font-weight: solid;
+}
+
+.items-send-btn{
+  margin: 40px 0 0;
+  width: 100%;
+  height: 50px;
+  background-color: #ea352d;
+  border: 1px solid #ea352d;
+  font-size: 14px;
+  color: white;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,5 +12,5 @@
 @import "./transactions";
 @import "./users";
 @import "./creditcard";
-@import "./item-content-box"
-
+@import "./item-content-box";
+@import "./item-edit";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,4 +16,23 @@ class ItemsController < ApplicationController
 
   def sell
   end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    # if item.seller_id == current_user.id ログイン実装完了後に指定
+    item.update(item_params)
+
+    redirect_to item_path
+    # end ログイン実装完了後に指定
+  end
+
+  private
+  def item_params
+  params.require(:item).permit(:name,:category_id,:introduction,:condition,:shippingfee,:shipfrom,:shipping_date,:price,:status,:size_id,:brand_id,:seller_id,:buyer_id)
+  end
+
 end

--- a/app/views/items/_edititem.html.haml
+++ b/app/views/items/_edititem.html.haml
@@ -1,0 +1,17 @@
+.item-description-for-sign_in
+  %p.itemdecription-in
+    = @item.introduction
+
+
+%section.itembox-container-signin
+
+  =link_to edit_item_path(@item.id) do
+    %button.send-edit-btn
+      商品の編集
+  %p.choice
+    or
+  %button.stop-sell-btn{type: "submit"}
+    出品を一旦停止する
+  = link_to "削除" do
+    %button.delete-sell-btn{type: "submit"}
+      この商品を削除する

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,203 @@
+/ 商品出品完了後に修正
+.mercari-header
+  %h1
+    = link_to root_path do
+      =image_tag asset_path "logo.svg", style: "background: rgb(245, 245, 245);"
+.sell-main-content.clearfix
+  .sell-item-container
+    .sell-container-inner
+      %h2.sell-container-header 商品の情報を入力
+    = form_with model: @item,class: "sell-form",method: :patch, local: true do |f|
+      .sell-upload-box
+        %h3.sell-upload-text
+          出品画像
+          %span.form-require 必須
+        %p.upload-image 最大10枚までアップロード出来ます
+        %label.sell-image-dropbox
+          =f.file_field :images, class: "sell-upload-drop-file", style: "display: none;"
+          %pre.visible-pc
+            ドラッグアンドドロップ
+            またはクリックしてファイルをアップロード
+      .sell-items-content.clearfix
+        .form-item-name
+          %label.sell-item-name
+            商品名
+            %span.form-require 必須
+        .input-form-groups
+          = f.text_field :name, class: "sell-item-name",placeholder: "商品名（必須40文字まで）"
+        .input-form-groups
+          .form-item-name
+            %label.sell-item-name
+              商品の説明
+              %span.form-require 必須
+          =f.text_area :introduction,class: "sell-item-info",type: "input",rows: "5", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
+      .sell-items-content.clearfix
+        %h3.sell-detail-text
+          商品の詳細
+        .sell-form-box
+          .sell-form-groups
+            %label.sell-item-name
+              カテゴリー
+              %span.form-require 必須
+              .select-edit-category
+                =f.select :category_id do
+                  %option{value: ""} ---
+                  %option{value: "1"} レディース
+                  %option{value: "2"} メンズ
+                  %option{value: "3"} ベビーキッズ
+                  %option{value: "4"} インテリア・住まい・小物
+                  %option{value: "5"} 本・音楽・ゲーム
+                  %option{value: "6"} おもちゃ・ホビー・グッズ
+                  %option{value: "7"} コスメ・香水・美容
+                  %option{value: "11"} 家電・スマホ・カメラ
+                  %option{value: "8"} スポーツ・レジャー
+                  %option{value: "9"} ハンドメイド
+                  %option{value: "10"} チケット
+                  %option{value: "11"} 自動車・オートバイ
+                  %option{value: "12"} その他
+                %i.fas.fa-angle-down
+
+          .sell-form-groups
+            %label.sell-item-name
+              ブランド
+              %span.form-require 任意
+              .select-edit-category
+                =f.select :brand_id do
+                  %option ---
+                  %option{value: "1"} シャネル
+                  %option{value: "2"} ナイキ
+                  %option{value: "3"} ルイ・ヴィトン
+                  %option{value: "4"}シュプリーム
+                  %option{value: "5"}アディダス
+                  %option{value: "6"}その他
+                %i.fas.fa-angle-down
+          .sell-form-groups
+            %label.sell-item-name
+              商品の状態
+              %span.form-require 必須
+              .select-edit-category
+                =f.select :condition do
+                  %option ---
+                  %option{value: "新品、未使用品"} 新品、未使用品
+                  %option{value: "未使用に近い"} 未使用に近い
+                  %option{value: "目立った傷や汚れなし"} 目立った傷や汚れなし
+                  %option{value: "やや傷や汚れあり"} やや傷や汚れあり
+                  %option{value: "全体的に状態が悪い"} 全体的に状態が悪い
+                %i.fas.fa-angle-down
+      .sell-items-content.clearfix
+        %h3.sell-detail-text
+          配送について
+          = link_to edit_item_path do
+            %i.fas.fa-question-circle
+        .sell-form-box
+          .sell-form-groups
+            %label.sell-item-name
+              発送料の負担
+              %span.form-require 必須
+              .select-edit-category#pare
+                =f.select :shippingfee do
+                  %option{value: ""} ---
+                  %option{value: "送料込み(出品者負担)"} 送料込み（出品者負担）
+                  %option{value: "着払い(購入者負担)"} 着払い（購入者負担）
+                %i.fas.fa-angle-down
+          .sell-form-groups#chi
+            %label.sell-item-name
+              配送の方法
+              %span.form-require 必須
+              .select-edit-category
+                =f.select :delivery do
+                  %option{value:""} ---
+                  %option{value: "未定"} 未定
+                  %option{value: "らくらくメルカリ便"} らくらくメルカリ便
+                  %option{value: "ゆうメール"} ゆうメール
+                  %option{value: "クロネコヤマト"} クロネコヤマト
+                %i.fas.fa-angle-down
+          .sell-form-groups
+            %label.sell-item-name
+              発送元の地域
+              %span.form-require 必須
+              .select-edit-category
+                =f.select :shipfrom do
+                  %option ---
+                  %option{value: "関西"} 関西
+                  %option{value: "北海道"} 北海道
+                  %option{value: "東北"} 東北
+                  %option{value: "関東"} 関東
+                  %option{value: "中部"} 中部
+                  %option{value: "四国"} 四国
+                  %option{value: "九州"} 九州
+                  %option{value: "沖縄"} 沖縄
+                %i.fas.fa-angle-down
+          .sell-form-groups
+            %label.sell-item-name
+              発送までの日数
+              %span.form-require 必須
+              .select-edit-category
+                =f.select :shipping_date do
+                  %option ---
+                  %option{value: "1~2日で発送"} 1~2日で発送
+                  %option{value: "2~3日で発送"} 2~3日で発送
+                  %option{value: "4~7日で発送"} 4~7日で発送
+                %i.fas.fa-angle-down
+                =f.select :size_id do
+                  %option ---
+                  %option{value: "1"} sサイズ
+                =f.select :status do
+                  %option --
+                  %option{value: "1"}販売中
+      .sell-items-content-calc
+        %h3.sell-price-text
+          販売価格(300〜9,999,999)
+          = link_to edit_item_path do
+            %i.fas.fa-question-circle
+        .sell-form-box
+          .sell-form-groups-list
+            .sell-item-price-left
+              %label.sell-item-name-left
+                価格
+                %span.form-require 必須
+            .sell-item-price-right
+              .input-form-groups
+                ¥
+                =f.text_field :price,class: "sell-item-price",placeholder: "例）300"
+          .sell-form-groups-list-calc
+            .sell-item-carc-left
+              販売手数料(10%)
+            .sell-item-carc-right
+              ー
+          .sell-form-groups-list-ans
+            .sell-item-ans-left
+              販売利益
+            .sell-item-ans-right -
+      .sell-items-content-btn
+        .sell-items-coution-box
+          =link_to edit_item_path, class: "sell-coution-message"  do
+            禁止されている出品
+          、
+          =link_to edit_item_path, class: "sell-coution-message" do
+            行為
+          を必ずご確認ください。
+          .coution-middle
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          =link_to edit_item_path, class: "sell-coution-message" do
+            偽ブランドの販売
+          は犯罪であり処罰される可能性があります。
+          .coution-bottom
+          また、出品を持ちまして
+          =link_to edit_item_path, class: "sell-coution-message" do
+            加盟店規約
+          に同意したことになります。
+        = f.submit "変更する", class: "items-send-btn"
+        %button.back-sell-btn
+          もどる
+.mercari-footer
+  %nav
+    %ul
+      %li プライバシーポリシー
+      %li メルカリ利用規約
+      %li 特定商取引に関する表記
+  .mercari-footer_contents
+    =link_to root_path, class: "single-footer-logo" do
+      =image_tag asset_path "mercari.svg", style: "background: rgb(245, 245, 245);"
+    %p
+      %small © 2019 Mercari

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -91,6 +91,10 @@
         = number_with_delimiter(@item.price)
       %span.item-tax (税込)
       %span.item-free 送料込み
+
+      / ログイン機能実装したら  - if user_signed_in? && item.seller_id == current_user.id を記述
+    = render "items/edititem"
+  %section.itembox-container
     =link_to '購入画面に進む',"",class: "btn item-buy"
     .item-description
       %p.itemdecription-in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "items#index"
-  resources :items, only: [:index,:show] do
+  resources :items, only: [:index, :show, :edit, :update] do
     collection do
       get 'sell'
     end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -22,4 +22,32 @@ describe ItemsController do
       expect(response).to render_template :show["id"]
     end
   end
+
+  describe 'Get #edit' do
+    it '@itemに要求されたitemを割り当てること' do
+      expect(assigns(:item)).to eq @item
+    end
+    it 'renders the :edit template' do
+      expect(response).to render_template :edit["id"]
+    end
+  end
+
+ describe 'Patch #update' do
+  context 'available item' do
+    before do
+      @item = create(:item)
+      @originalname = @item.name
+    end
+    context 'valid parameter' do
+      it 'requests 200 has to be redirect' do
+        expect(response.status).to eq 200
+      end
+      it 'updates the datebase' do
+        @item.reload
+        expect(@item.name).to eq 'hello item!'
+      end
+    end
+  end
+end
+
 end


### PR DESCRIPTION
# What
商品詳細ページに編集ボタンを実装。
ログインしていたらrenderで呼び出すように指定を想定し、部分テンプレートとした。
商品編集ボタンよりedit.html.hamlを呼びだすようにコントローラーに記述。
編集完了後は商品詳細ページにリダイレクトするようにした。
# Why
ログイン機能実装がまだ終わっておらず、ログイン時とそうでない時の表示の変更はログイン機能実装完了後とする（コメントアウトの部分）
商品出品ページの内容を生かすため、ビューの表示は商品出品のタスクが完了後とする。
それに伴い、トレロに多機能の実装待ちの項目を作り、そこで本件のタスクを管理する。
DBから出したアイテムの内容を変更して保存するところまでを実装しております。

https://gyazo.com/31a38fd9298d8a2f02857c50a2d2a6b0

https://gyazo.com/4e221ce5ca09ec4f8d305ddc830d6c84