### PR TITLE
ヘッダー部分の商品検索の実装

### DIFF
--- a/app/assets/stylesheets/_markets.scss
+++ b/app/assets/stylesheets/_markets.scss
@@ -5,6 +5,7 @@ body{
   padding: 0;
   background-color: #f5f5f5;
       font-family: 'Source Sans Pro', Helvetica , Arial, 'æ¸¸ã‚´ã‚·ãƒƒã‚¯ä½“', 'YuGothic', 'ãƒ¡ã‚¤ãƒªã‚ª', 'Meiryo', sans-serif;
+      -webkit-appearance: none;
 }
 
 .pc-header{

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -252,11 +252,11 @@ label#condition-box {
 }
 
 .search-form-ship-list {
-margin-top: 190px;
+  margin-top: 190px;
 }
 
 .search-form-cart-list {
-margin-top: 100px;
+  margin-top: 100px;
 }
 
 .search-form-buttons {
@@ -266,29 +266,29 @@ margin-top: 100px;
 }
 
 .items-search-clear-btn{
-    margin: 40px 0 20px;
-    width: 40%;
-    height: 50px;
-    background-color: #aaa;
-    border: 1px solid #aaa;
-    font-size: 14px;
-    color: white;
-    display: inline-block;
-    float: left;
-    line-height: 50px;
-    -webkit-appearance: none;
+  margin: 40px 0 20px;
+  width: 40%;
+  height: 50px;
+  background-color: #aaa;
+  border: 1px solid #aaa;
+  font-size: 14px;
+  color: white;
+  display: inline-block;
+  float: left;
+  line-height: 50px;
+  -webkit-appearance: none;
 }
 
 .items-search-finish-btn{
-    margin: 40px 20px 20px;
-    width: 40%;
-    height: 50px;
-    background-color: #ea352d;
-    border: 1px solid #ea352d;
-    font-size: 14px;
-    color: white;
-    display: inline-block;
-    float: right;
-    line-height: 50px;
-    -webkit-appearance: none;
+  margin: 40px 20px 20px;
+  width: 40%;
+  height: 50px;
+  background-color: #ea352d;
+  border: 1px solid #ea352d;
+  font-size: 14px;
+  color: white;
+  display: inline-block;
+  float: right;
+  line-height: 50px;
+  -webkit-appearance: none;
 }

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,0 +1,294 @@
+.search-container {
+  margin: 40px auto 0;
+  width: 1020px;
+}
+
+.search-content {
+  float: right;
+  width: 700px;
+  display: block;
+}
+
+h2.search-result-head {
+  margin: 0 0 8px;
+}
+
+.search-items-content {
+  width: auto;
+  text-decoration: none;
+}
+
+.search-item-box {
+  margin-left: 0;
+  display: inline-block;
+  margin: 0 0 20px 10px;
+  background-color: white;
+  a{
+    text-decoration: none;
+  }
+}
+
+.items-box-photo {
+  width: 160px;
+  height: 160px;
+  position: relative;
+  img {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    width: 160px;
+    height: 160px;
+  }
+}
+
+.search-box-body {
+  height: 110px;
+  width: 160px;
+}
+
+.items-box-name {
+  padding: 0 16px 0 16px;
+  overflow: hidden;
+  position: relative;
+  font-weight: 400;
+  height: 3em;
+  line-height: 1.5;
+  word-break: break-word;
+  white-space: normal;
+  font-size: 16px;
+  font-weight: 400;
+  color: #333;
+}
+
+.items-box-price {
+  font-weight: 400;
+  color: #333;
+  padding-left: 16px;
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 15px;
+}
+
+.item-box-tax {
+  font-size: 10px;
+  clear: both;
+  font-weight: normal;
+}
+
+.search-side-content {
+  float: left;
+  width: 280px;
+  margin: 0 40px 0 0;
+}
+
+.search-sort .search-select-wrap {
+  text-align: left;
+  position: relative;
+  .fa-angle-down:before {
+    position: absolute;
+    left: 20vw;
+    top: 15px;
+  }
+}
+
+select#sort-order {
+  width: 280px;
+  height: 48px;
+  padding: 0 16px;
+  background: #fff;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  position: relative;
+  -webkit-appearance: none;
+}
+.search-dropdown-content.search-extend{
+  position: static;
+  display: block;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  background-color: white;
+  width: 265px;
+  float: left;
+  margin-top: 40px;
+  padding-left: 16px;
+}
+
+h3.search-more {
+  font-size: 16px;
+  vertical-align: top;
+  line-height: 16px;
+}
+
+.icon-plus {
+  position: relative;
+  top: -1px;
+  margin: 0 4px 0 0;
+  color: #888;
+  font-size: 16px;
+  vertical-align: middle;
+    .fa-angle-down:before {
+    position: absolute;
+    left: 18vw;
+    top: 40px;
+  }
+}
+
+span.keyword {
+  color: black;
+  font-size: 14px;
+  vertical-align: middle;
+  font-weight: bold;
+}
+
+.search-form-group {
+  width: 250px;
+  height: 50px;
+}
+
+input#left-search-input {
+  width: 240px;
+  height: 50px;
+  font-size: 14px;
+  margin: 5px auto;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding-left: 10px;
+}
+
+.search-form-group-list {
+  margin-top: 60px;
+
+}
+
+select#choice-category {
+  width: 250px;
+  height: 48px;
+  padding: 10px ;
+  background: #fff;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  position: relative;
+  -webkit-appearance: none;
+}
+
+.search-form-group-tag {
+  margin-top: 30px;
+}
+
+input#brand-search-input {
+  width: 240px;
+  height: 50px;
+  font-size: 14px;
+  margin: 5px auto;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding-left: 10px;
+}
+
+.search-form-size-list {
+  margin-top: 30px;
+}
+
+select#price-category {
+  width: 250px;
+  height: 48px;
+  padding: 10px ;
+  background: #fff;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  position: relative;
+  -webkit-appearance: none;
+}
+
+input#min-price-input {
+  width: 40%;
+  height: 40px;
+  font-size: 14px;
+  margin: 5px auto;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding-left: 10px;
+}
+
+input#max-price-input {
+  width: 40%;
+  height: 40px;
+  font-size: 14px;
+  margin: 5px auto;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding-left: 10px;
+}
+
+input#item_conditon {
+  width: 28px;
+}
+
+.condition-check-box {
+  display: block;
+  width: 90%;
+  vertical-align: middle;
+  word-break: break-word;
+  font-size: 14px;
+}
+
+.condition-check-box-left {
+  display: inline-block;
+  float: left;
+  width: 40%;
+}
+
+.condition-check-box-right {
+  display: inline-block;
+  float: right;
+  width: 40%;
+}
+
+label#condition-box {
+  font-size: 14px;
+}
+
+.search-form-ship-list {
+margin-top: 190px;
+}
+
+.search-form-cart-list {
+margin-top: 100px;
+}
+
+.search-form-buttons {
+  margin-top: 50px;
+  display: block;
+  text-align: center;
+}
+
+.items-search-clear-btn{
+    margin: 40px 0 20px;
+    width: 40%;
+    height: 50px;
+    background-color: #aaa;
+    border: 1px solid #aaa;
+    font-size: 14px;
+    color: white;
+    display: inline-block;
+    float: left;
+    line-height: 50px;
+    -webkit-appearance: none;
+}
+
+.items-search-finish-btn{
+    margin: 40px 20px 20px;
+    width: 40%;
+    height: 50px;
+    background-color: #ea352d;
+    border: 1px solid #ea352d;
+    font-size: 14px;
+    color: white;
+    display: inline-block;
+    float: right;
+    line-height: 50px;
+    -webkit-appearance: none;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import "./item-content-box";
 @import "./item-edit";
 @import "./modal";
+@import "./search";

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,10 +46,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def search
+    @items = Item.includes(:item_images).where('name LIKE(?)', "%#{params[:keyword]}%").limit(48)
+  end
+
+
   private
+
   def item_params
     params.require(:item).permit(:name,:brand_id,:delivery,:category_id,:introduction,:condition,:shippingfee,:shipfrom,:shipping_date,:price,:status,:size_id,item_images_attributes:[:image]).merge(seller_id: current_user.id)
   end
-
 
 end

--- a/app/views/items/_left_search_form.html.haml
+++ b/app/views/items/_left_search_form.html.haml
@@ -1,5 +1,5 @@
 .side-serch-content
-  =form_with url:'/items/search', action: :novalidate, class: "left-search-form", local: true do |f|
+  =form_with url:search_items_path, action: :novalidate, class: "left-search-form", local: true do |f|
     .search-sort
       .search-select-wrap
         =f.select "sort-order" do

--- a/app/views/items/_left_search_form.html.haml
+++ b/app/views/items/_left_search_form.html.haml
@@ -1,0 +1,131 @@
+.side-serch-content
+  =form_with url:'/items/search', action: :novalidate, class: "left-search-form", local: true do |f|
+    .search-sort
+      .search-select-wrap
+        =f.select "sort-order" do
+          %option 並び替え
+          %option{value: "price_asc"}    価格の安い順
+          %option{value: "price_desc"}   価格の高い順
+          %option{value: "created_asc"}  出品の古い順
+          %option{value: "created_desc"} 出品の新しい順
+          %option{value: "like_desc"}    いいね！の多い順
+        = fa_icon("angle-down")
+
+    .search-dropdown-content.search-extend
+      %h3.search-more
+        詳細検索
+      .search-form-group
+        .icon-plus
+          = fa_icon("plus")
+          %span.keyword キーワードを追加する
+          =f.text_field :"left-search-input", class: "left-search-input", value: "検索", name: "keyword", type: "text",placeholder: "例）値下げ"
+
+      .search-form-group-list
+        .icon-plus
+          = fa_icon("list")
+          %span.keyword カテゴリーを選択する
+          =f.select "choice-category" do
+            %option すべて
+            %option{value: "category"}    カテゴリー
+          = fa_icon("angle-down")
+      .search-form-group-tag
+        .icon-plus
+          = fa_icon("tag")
+          %span.keyword ブランド名から探す
+          =f.text_field :"brand-search-input", class: "brand-search-input", value: "", name: "keyword", type: "text",placeholder: "例）シャネル"
+
+      .search-form-size-list
+        .icon-plus
+          = fa_icon("vector-square")
+          %span.keyword サイズを指定する
+          =f.select "choice-category" do
+            %option すべて
+            %option{value: "size"} サイズ
+          = fa_icon("angle-down")
+
+      .search-form-size-list
+        .icon-plus
+          = fa_icon("coins")
+          %span.keyword 価格
+          =f.select "price-category" do
+            %option 選択してください
+            %option{value: "price"} 300 ~ 1000
+          = fa_icon("angle-down")
+        .icon-plus
+          =f.text_field :"min-price-input", class: "min-price-input", value: "", name: "keyword", type: "text",placeholder: "¥ Min"
+          %span ~
+          =f.text_field :"max-price-input", class: "max-price-input", value: "", name: "keyword", type: "text",placeholder: "¥ Max"
+
+      .search-form-size-list
+        .icon-plus
+          = fa_icon("star")
+          %span.keyword 商品の状態
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_condition, {checked: :true}
+            %span
+            = f.label :condition, "すべて",id: "condition-box"
+          .condition-check-box-right
+            = f.check_box :item_condition, {checked: :true}
+            = f.label :condition, "新品・未使用品",id: "condition-box"
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_condition, {checked: :true}
+            %span
+            = f.label :condition, "未使用に近い",id: "condition-box"
+          .condition-check-box-right
+            = f.check_box :item_condition, {checked: :true}
+            = f.label :condition, "目立った傷や汚れなし",id: "condition-box"
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_condition, {checked: :true}
+            = f.label :condition, "やや傷や汚れあり",id: "condition-box"
+          .condition-check-box-right
+            = f.check_box :item_condition, {checked: :true}
+            = f.label :condition, "傷や汚れあり",id: "condition-box"
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_condition, {checked: :true}
+            = f.label :condition, "全体的に状態が悪い",id: "condition-box"
+
+      .search-form-ship-list
+        .icon-plus
+          = fa_icon("truck-moving")
+          %span.keyword 配送料の負担
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_shipping, {checked: :true}
+            %span
+            = f.label :shipping, "すべて",id: "shippng-box"
+          .condition-check-box-right
+            = f.check_box :item_shipping, {checked: :true}
+            = f.label :shipping, "着払い(購入者負担)",id: "shipping-box"
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_shipping, {checked: :true}
+            %span
+            = f.label :shipping, "送料込み(出品者負担)",id: "shipping-box"
+
+      .search-form-cart-list
+        .icon-plus
+          = fa_icon("shopping-cart")
+          %span.keyword 販売状況
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_status, {checked: :true}
+            %span
+            = f.label :status, "すべて",id: "status-box"
+          .condition-check-box-right
+            = f.check_box :item_shipping, {checked: :true}
+            = f.label :status, "販売中",id: "status-box"
+        .condition-check-box
+          .condition-check-box-left
+            = f.check_box :item_status, {checked: :true}
+            %span
+            = f.label :status, "売り切れ",id: "status-box"
+
+        .search-form-buttons
+          %button.items-search-clear-btn
+            クリア
+          %button.items-search-finish-btn
+            完了

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -13,7 +13,7 @@
 .search-container.clearfix
   .search-content
     %h2.search-result-head
-      - if @items.count == nil
+      - if @items.count == 0
         検索結果 0件
       -else
         検索結果 1-#{@items.count}件
@@ -35,9 +35,3 @@
                   (税込)
 
   = render "items/left_search_form"
-
-
-
-
-
-

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,43 @@
+= render "layouts/header"
+
+.item-content-box-main
+  %nav.bread-crumbs
+    %ul
+      %li
+        %span{itemprop: "title"}
+          - breadcrumb :search_items, @items
+      %li{itemscope: "", itemtype: ""}
+        %span{itemprop: "title"}
+          = breadcrumbs separator: " #{content_tag(:i, '', :class=>'fa fa-angle-right')} "
+
+.search-container.clearfix
+  .search-content
+    %h2.search-result-head
+      - if @items.count == nil
+        検索結果 0件
+      -else
+        検索結果 1-#{@items.count}件
+    .search-items-content.clearfix
+      - @items.each do |item|
+        .search-item-box
+          =link_to root_path do
+            .items-box-photo
+              -item.item_images.each.with_index do |image, i|
+                - if i ==0
+                  =image_tag image.image.url
+            .search-box-body
+              %p.items-box-name
+                = item.name
+              .items-box-price
+                ¥
+                = number_with_delimiter(item.price)
+                %p.item-box-tax
+                  (税込)
+
+  = render "items/left_search_form"
+
+
+
+
+
+

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -4,7 +4,7 @@
       %h1.pc-left
         = link_to "/" do
           =image_tag asset_path("logo.svg"),alt: "mercari"
-      =form_with url:'/items/search', method: :get, class: "pc-header-form", local: true do
+      =form_with url:search_items_path, method: :get, class: "pc-header-form", local: true do
         %input.input{name: "keyword", placeholder: "キーワードから探す", type: "search"}/
         %i.fas.fa-search
     .clearfix-box

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -4,7 +4,7 @@
       %h1.pc-left
         = link_to "/" do
           =image_tag asset_path("logo.svg"),alt: "mercari"
-      %form.pc-header-form{action: ""}
+      =form_with url:'/items/search', method: :get, class: "pc-header-form", local: true do
         %input.input{name: "keyword", placeholder: "キーワードから探す", type: "search"}/
         %i.fas.fa-search
     .clearfix-box

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -41,3 +41,8 @@ crumb :users_sign_out do |user|
   link "ログアウト", users_sign_out_path
   parent :users_show
 end
+
+crumb :search_items do |user|
+  link "#{params[:keyword]}", search_items_path
+  parent :root
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
     collection do
       get 'sell'
+      get 'search'
     end
   end
   get 'users/signin_form', to: 'users#signin_form'


### PR DESCRIPTION
# What
ヘッダー部分の検索フォームより検索機能を実装
・searchをルーティングとコントローラーに追加
・左側の詳細検索部分は後に実装するため部分テンプレートとした。
・検索キーワードをwhere name LIKE?で検索させ、検索結果に件数を.countで表示させるようにした。
・パンくずにも検索キーワードを表示させるようにした。
# Why
左側の詳細検索はgemの仕様も検討しているが、のちの実装となるため分け、データ等も仮置きとした。
表示部分には件数が0であれば0件と表示させ、検索がヒットすれば、1 ~ 〇〇件と表示させるように条件分岐させた。

https://gyazo.com/76ac26560e7e1a87289b13ec184c0300